### PR TITLE
Fix `failed to fetch an image or build from source` problem

### DIFF
--- a/.github/workflows/build-and-push-release-image.yml
+++ b/.github/workflows/build-and-push-release-image.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Login to Docker Hub
         uses: docker/login-action@v2
         with:
-          username: fwing
+          username: hu3rror
           password: ${{ secrets.DOCKER_NEOSMEMO_TOKEN }}
 
       - name: Set up Docker Buildx
@@ -42,4 +42,4 @@ jobs:
           file: ./Dockerfile
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: fwing/memos-fly:latest, fwing/memos-fly:${{ env.VERSION }}
+          tags: hu3rror/memos-fly:latest, hu3rror/memos-fly:${{ env.VERSION }}

--- a/.github/workflows/build-and-push-release-image.yml
+++ b/.github/workflows/build-and-push-release-image.yml
@@ -24,13 +24,14 @@ jobs:
       - name: Login to Docker Hub
         uses: docker/login-action@v2
         with:
-          username: hu3rror
+          username: fwing
           password: ${{ secrets.DOCKER_NEOSMEMO_TOKEN }}
 
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v2
         with:
+          version: v0.9.1
           install: true
 
       - name: Build and Push
@@ -41,4 +42,4 @@ jobs:
           file: ./Dockerfile
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: hu3rror/memos-fly:latest, hu3rror/memos-fly:${{ env.VERSION }}
+          tags: fwing/memos-fly:latest, fwing/memos-fly:${{ env.VERSION }}


### PR DESCRIPTION
The docker toolchain upgrade breaks the manifest and thus fly.io has trouble finding the image on docker hub
The simplest solution is to set it to a specific version of docker/setup-buildx-action@v2

Ref: https://github.com/docker/build-push-action/issues/755